### PR TITLE
Add TypesOnly param for TypeScript client

### DIFF
--- a/gen/gen.go
+++ b/gen/gen.go
@@ -10,7 +10,7 @@ import (
 	"golang.org/x/text/language"
 )
 
-const version = "2.4.6"
+const version = "2.4.7"
 
 const DefinitionsPrefix = "#/definitions/"
 

--- a/typescript/rpcgen_test.go
+++ b/typescript/rpcgen_test.go
@@ -58,3 +58,28 @@ func TestGenerateTypeScriptClasses(t *testing.T) {
 		t.Fatalf("bad generator output")
 	}
 }
+
+func TestGenerateTypeScriptTypesOnly(t *testing.T) {
+	rpc := zenrpc.NewServer(zenrpc.Options{})
+	rpc.Register("catalogue", testdata.CatalogueService{})
+
+	cl := NewClient(rpc.SMD(), Settings{TypesOnly: true})
+
+	generated, err := cl.Generate()
+	if err != nil {
+		t.Fatalf("generate typescript client: %v", err)
+	}
+
+	testData, err := os.ReadFile("./testdata/catalogue_with_types_only.ts")
+	if err != nil {
+		t.Fatalf("open test data file: %v", err)
+	}
+
+	// cut first line with version from comparsion
+	_, generatedBody, _ := bytes.Cut(generated, []byte{'\n'})
+	_, testDataBody, _ := bytes.Cut(testData, []byte{'\n'})
+
+	if !bytes.Equal(generatedBody, testDataBody) {
+		t.Fatalf("bad generator output")
+	}
+}

--- a/typescript/testdata/catalogue_with_types_only.ts
+++ b/typescript/testdata/catalogue_with_types_only.ts
@@ -1,0 +1,37 @@
+/* Code generated from jsonrpc schema by rpcgen v2.4.0; DO NOT EDIT. */
+/* eslint-disable */
+export interface ICampaign {
+  id: number,
+  groups: Array<IGroup>
+}
+
+export interface ICatalogueFirstParams {
+  groups: Array<IGroup>
+}
+
+export interface ICatalogueSecondParams {
+  campaigns: Array<ICampaign>
+}
+
+export interface IGroup {
+  id: number,
+  title: string,
+  nodes: Array<IGroup>,
+  groups: Array<IGroup>,
+  child?: IGroup,
+  sub: ISubGroup
+}
+
+export interface ISubGroup {
+  id: number,
+  title: string,
+  nodes: Array<IGroup>
+}
+
+export interface RpcMethods {
+  catalogue: {
+    first(params: ICatalogueFirstParams): Promise<boolean>,
+    second(params: ICatalogueSecondParams): Promise<boolean>,
+    third(): Promise<ICampaign>
+  }
+}

--- a/typescript/typescript_client.go
+++ b/typescript/typescript_client.go
@@ -90,6 +90,7 @@ type tsService struct {
 	HasParams bool
 	Params    string
 	Response  string
+	Comment   string
 }
 
 type tsModels struct {
@@ -202,6 +203,8 @@ skipNS:
 			nIdx = len(models.Namespaces) - 1
 		}
 
+		fmt.Printf("[%s] Description: %q\n", serviceName, service.Description)
+
 		// add service to TypeScript services
 		respService := tsService{
 			Namespace: namespace,
@@ -210,6 +213,7 @@ skipNS:
 			HasParams: false,
 			Params:    "",
 			Response:  respType.Type,
+			Comment:   service.Description,
 		}
 		if len(service.Parameters) > 0 {
 			respService.HasParams = true

--- a/typescript/typescript_client.go
+++ b/typescript/typescript_client.go
@@ -30,6 +30,7 @@ type Settings struct {
 	TypeMapper        TypeMapper
 	ExcludedNamespace []string
 	WithClasses       bool
+	TypesOnly         bool
 }
 
 func NewClient(schema smd.Schema, settings Settings) *Generator {
@@ -94,6 +95,7 @@ type tsService struct {
 type tsModels struct {
 	gen.GeneratorData
 	WithClasses bool
+	TypesOnly   bool
 	Interfaces  []tsInterface
 	Namespaces  []tsServiceNamespace
 }
@@ -238,6 +240,7 @@ skipNS:
 	}
 
 	models.WithClasses = g.settings.WithClasses
+	models.TypesOnly = g.settings.TypesOnly
 
 	return models
 }

--- a/typescript/typescript_client.go
+++ b/typescript/typescript_client.go
@@ -203,8 +203,6 @@ skipNS:
 			nIdx = len(models.Namespaces) - 1
 		}
 
-		fmt.Printf("[%s] Description: %q\n", serviceName, service.Description)
-
 		// add service to TypeScript services
 		respService := tsService{
 			Namespace: namespace,

--- a/typescript/typescript_template.go
+++ b/typescript/typescript_template.go
@@ -24,6 +24,19 @@ export class {{ .ModelName }} implements {{ .Name }} {
 {{ end }}
 
 {{- end }}
+{{- if .TypesOnly }}
+export interface RpcMethods {
+{{- $lenN := len .Namespaces }}
+{{- range $i,$e := .Namespaces }}
+  {{ .Name }}: {
+{{- $lenS := len .Services }}
+{{- range $i, $e := .Services }}
+    {{ .NameLCF }}({{ if .HasParams }}params: {{ .Params }}{{ end }}): Promise<{{ .Response }}>{{ if ne $i $lenS }},{{ end }}
+{{- end }}
+  }{{ if ne $i $lenN }},{{ end }}
+{{- end }}
+}
+{{- else }}
 export const factory = (send: any) => ({
 {{- $lenN := len .Namespaces }}
 {{- range $i,$e := .Namespaces }}
@@ -37,4 +50,5 @@ export const factory = (send: any) => ({
   }{{ if ne $i $lenN }},{{ end }}
 {{- end }}
 })
+{{- end }}
 `

--- a/typescript/typescript_template.go
+++ b/typescript/typescript_template.go
@@ -31,6 +31,11 @@ export interface RpcMethods {
   {{ .Name }}: {
 {{- $lenS := len .Services }}
 {{- range $i, $e := .Services }}
+{{- if ne .Comment "" }}
+    /**
+     * {{ .Comment }}
+     */
+{{- end }}
     {{ .NameLCF }}({{ if .HasParams }}params: {{ .Params }}{{ end }}): Promise<{{ .Response }}>{{ if ne $i $lenS }},{{ end }}
 {{- end }}
   }{{ if ne $i $lenN }},{{ end }}
@@ -43,6 +48,11 @@ export const factory = (send: any) => ({
   {{ .Name }}: {
 {{- $lenS := len .Services }}
 {{- range $i, $e := .Services }}
+{{- if ne .Comment "" }}
+    /**
+     * {{ .Comment }}
+     */
+{{- end }}
     {{ .NameLCF }}({{ if .HasParams }}params: {{ .Params }}{{ end }}): Promise<{{ .Response }}> {
       return send('{{ .Namespace }}.{{ .Name }}'{{ if .HasParams }}, params{{ end }})
     }{{ if ne $i $lenS }},{{ end }}


### PR DESCRIPTION
- Добавлен TypesOnly параметр, по которому в шаблоне, вместо объекта с набором методов, генерируется интерфейс этого объекта
- Добавлена генерация jsdoc комментариев из Service.Description