### PR TITLE
Add typeName parameter to TypeScript TypeMapper

### DIFF
--- a/typescript/typescript_client.go
+++ b/typescript/typescript_client.go
@@ -38,7 +38,7 @@ func NewClient(schema smd.Schema, settings Settings) *Generator {
 	return &Generator{schema: schema, settings: settings}
 }
 
-type TypeMapper func(in smd.JSONSchema, tsType Type) Type
+type TypeMapper func(typeName string, in smd.JSONSchema, tsType Type) Type
 
 // Generate returns generate TypeScript client
 func (g *Generator) Generate() ([]byte, error) {
@@ -178,7 +178,7 @@ skipNS:
 		if len(service.Parameters) > 0 {
 			tsTypes := make([]Type, len(service.Parameters))
 			for i := range service.Parameters {
-				tsTypes[i] = convertTSType(&models, interfacesCache, service.Parameters[i], "", g.settings.TypeMapper)
+				tsTypes[i] = convertTSType(&models, interfacesCache, service.Parameters[i], "", g.settings.TypeMapper, interfaceName)
 			}
 			addTSInterface(&models, interfacesCache, tsInterface{
 				Name:       interfaceName,
@@ -187,7 +187,7 @@ skipNS:
 		}
 
 		// add service "returns" as TypeScript interface
-		respType := convertTSType(&models, interfacesCache, service.Returns, "", g.settings.TypeMapper)
+		respType := convertTSType(&models, interfacesCache, service.Returns, "", g.settings.TypeMapper, "")
 
 		// add namespace to TypeScript services
 		nIdx := -1
@@ -293,7 +293,7 @@ func convertTSScalar(t string) string {
 }
 
 // convertTSType converts smd.JSONSchema to Type.
-func convertTSType(models *tsModels, interfacesCache map[string]interface{}, in smd.JSONSchema, comment string, typeMapper TypeMapper) Type {
+func convertTSType(models *tsModels, interfacesCache map[string]interface{}, in smd.JSONSchema, comment string, typeMapper TypeMapper, typeName string) Type {
 	result := Type{
 		Name:     in.Name,
 		Comment:  comment,
@@ -341,16 +341,17 @@ func convertTSType(models *tsModels, interfacesCache map[string]interface{}, in 
 
 	// apply hook
 	if typeMapper != nil {
-		result = typeMapper(in, result)
+		result = typeMapper(typeName, in, result)
 	}
 
 	return result
 }
 
 // addTSComplexInterface converts complex type stored in smd1.JSONSchema to tsInterface and adds it to client.
-func addTSComplexInterface(models *tsModels, interfacesCache map[string]interface{}, in smd.JSONSchema, typeMapper func(in smd.JSONSchema, tsType Type) Type) {
+func addTSComplexInterface(models *tsModels, interfacesCache map[string]interface{}, in smd.JSONSchema, typeMapper TypeMapper) {
 	var tsTypes []Type
 
+	typeName := interfacePrefix + in.TypeName
 	for _, p := range in.Properties {
 		tsTypes = append(tsTypes, convertTSType(models, interfacesCache, smd.JSONSchema{
 			Name:        p.Name,
@@ -358,7 +359,7 @@ func addTSComplexInterface(models *tsModels, interfacesCache map[string]interfac
 			Description: strings.TrimPrefix(p.Ref, gen.DefinitionsPrefix),
 			Type:        p.Type,
 			Items:       p.Items,
-		}, p.Description, typeMapper))
+		}, p.Description, typeMapper, typeName))
 	}
 
 	addTSInterface(models, interfacesCache, tsInterface{


### PR DESCRIPTION
### Problem
The TypeMapper hook currently receives only the JSON Schema definition and the converted TypeScript type. This is enough to map fields by name, but there is no way to know which interface the field belongs to.                                                                                             
                                                                                                                                                                                
In practice this is a problem when different RPC methods have parameters with the same field name but different semantics.  Without the parent type name the mapper cannot distinguish between them and is forced to use the same union for all.                                                                      
                                                            
### Changes                                                                                                                                                                       
- Added typeName string as the first parameter of the TypeMapper function type. It contains the name of the TypeScript interface being generated, or an empty string for top-level return types.           
- Passed typeName through convertTSType and addTSComplexInterface.                                                                                                            
- Replaced inline func(in smd.JSONSchema, tsType Type) Type with TypeMapper alias in addTSComplexInterface signature for consistency.                                         
                                                                                                                                                                                
### Breaking change                                                                                                                                                               
                                                                                                                                                                                
The signature of TypeMapper has changed. Migration requires adding one parameter:                                                                                             
```
// before                                                                                                                                                                     
func(in smd.JSONSchema, tsType typescript.Type) typescript.Type
                                                                                                                                                                                
// after
func(typeName string, in smd.JSONSchema, tsType typescript.Type) typescript.Type 
```