### PR TITLE
Fix handle nullable types in typescript generated client

### DIFF
--- a/typescript/testdata/catalogue_client.ts
+++ b/typescript/testdata/catalogue_client.ts
@@ -18,7 +18,7 @@ export interface IGroup {
   title: string,
   nodes: Array<IGroup>,
   groups: Array<IGroup>,
-  child?: IGroup,
+  child: IGroup | null,
   sub: ISubGroup
 }
 

--- a/typescript/testdata/catalogue_client.ts
+++ b/typescript/testdata/catalogue_client.ts
@@ -18,7 +18,7 @@ export interface IGroup {
   title: string,
   nodes: Array<IGroup>,
   groups: Array<IGroup>,
-  child: IGroup | null,
+  child?: IGroup | null,
   sub: ISubGroup
 }
 

--- a/typescript/testdata/catalogue_with_classes.ts
+++ b/typescript/testdata/catalogue_with_classes.ts
@@ -18,7 +18,7 @@ export interface IGroup {
   title: string,
   nodes: Array<IGroup>,
   groups: Array<IGroup>,
-  child: IGroup | null,
+  child?: IGroup | null,
   sub: ISubGroup
 }
 
@@ -54,7 +54,7 @@ export class Group implements IGroup {
   title: string = null!;
   nodes: Array<IGroup> = null!;
   groups: Array<IGroup> = null!;
-  child: IGroup | null = null;
+  child?: IGroup | null = null;
   sub: ISubGroup = null!;
 }
 

--- a/typescript/testdata/catalogue_with_classes.ts
+++ b/typescript/testdata/catalogue_with_classes.ts
@@ -18,7 +18,7 @@ export interface IGroup {
   title: string,
   nodes: Array<IGroup>,
   groups: Array<IGroup>,
-  child?: IGroup,
+  child: IGroup | null,
   sub: ISubGroup
 }
 
@@ -32,38 +32,38 @@ export class Campaign implements ICampaign {
   static entityName = "campaign";
 
   id: number = 0;
-  groups: Array<IGroup> = null;
+  groups: Array<IGroup> = null!;
 }
 
 export class CatalogueFirstParams implements ICatalogueFirstParams {
   static entityName = "cataloguefirstparams";
 
-  groups: Array<IGroup> = null;
+  groups: Array<IGroup> = null!;
 }
 
 export class CatalogueSecondParams implements ICatalogueSecondParams {
   static entityName = "cataloguesecondparams";
 
-  campaigns: Array<ICampaign> = null;
+  campaigns: Array<ICampaign> = null!;
 }
 
 export class Group implements IGroup {
   static entityName = "group";
 
   id: number = 0;
-  title: string = null;
-  nodes: Array<IGroup> = null;
-  groups: Array<IGroup> = null;
-  child?: IGroup = null;
-  sub: ISubGroup = null;
+  title: string = null!;
+  nodes: Array<IGroup> = null!;
+  groups: Array<IGroup> = null!;
+  child: IGroup | null = null;
+  sub: ISubGroup = null!;
 }
 
 export class SubGroup implements ISubGroup {
   static entityName = "subgroup";
 
   id: number = 0;
-  title: string = null;
-  nodes: Array<IGroup> = null;
+  title: string = null!;
+  nodes: Array<IGroup> = null!;
 }
 
 export const factory = (send: any) => ({

--- a/typescript/testdata/catalogue_with_types_only.ts
+++ b/typescript/testdata/catalogue_with_types_only.ts
@@ -18,7 +18,7 @@ export interface IGroup {
   title: string,
   nodes: Array<IGroup>,
   groups: Array<IGroup>,
-  child?: IGroup,
+  child: IGroup | null,
   sub: ISubGroup
 }
 

--- a/typescript/testdata/catalogue_with_types_only.ts
+++ b/typescript/testdata/catalogue_with_types_only.ts
@@ -18,7 +18,7 @@ export interface IGroup {
   title: string,
   nodes: Array<IGroup>,
   groups: Array<IGroup>,
-  child: IGroup | null,
+  child?: IGroup | null,
   sub: ISubGroup
 }
 

--- a/typescript/typescript_client.go
+++ b/typescript/typescript_client.go
@@ -74,7 +74,7 @@ type Type struct {
 	Name       string
 	Comment    string
 	Type       string
-	Nullable   bool
+	Optional   bool
 	HasDefault bool
 	Default    *string
 }
@@ -147,7 +147,7 @@ func (t Type) DefaultTmpl() string {
 		}
 	}
 
-	if result == "null" && !t.Nullable {
+	if result == "null" && !t.Optional {
 		result = "null!"
 	}
 
@@ -302,7 +302,7 @@ func convertTSType(models *tsModels, interfacesCache map[string]interface{}, in 
 		Name:     in.Name,
 		Comment:  comment,
 		Type:     convertTSScalar(in.Type),
-		Nullable: in.Optional,
+		Optional: in.Optional,
 	}
 
 	// detect array sub type
@@ -343,7 +343,7 @@ func convertTSType(models *tsModels, interfacesCache map[string]interface{}, in 
 		}, typeMapper)
 	}
 
-	if result.Nullable {
+	if result.Optional {
 		result.Type += " | null"
 	}
 

--- a/typescript/typescript_client.go
+++ b/typescript/typescript_client.go
@@ -74,7 +74,7 @@ type Type struct {
 	Name       string
 	Comment    string
 	Type       string
-	Optional   bool
+	Nullable   bool
 	HasDefault bool
 	Default    *string
 }
@@ -145,6 +145,10 @@ func (t Type) DefaultTmpl() string {
 		case "Array<boolean>":
 			result = "[false]"
 		}
+	}
+
+	if result == "null" && !t.Nullable {
+		result = "null!"
 	}
 
 	return result
@@ -298,7 +302,7 @@ func convertTSType(models *tsModels, interfacesCache map[string]interface{}, in 
 		Name:     in.Name,
 		Comment:  comment,
 		Type:     convertTSScalar(in.Type),
-		Optional: in.Optional,
+		Nullable: in.Optional,
 	}
 
 	// detect array sub type
@@ -337,6 +341,12 @@ func convertTSType(models *tsModels, interfacesCache map[string]interface{}, in 
 			Type:        d.Type,
 			Properties:  d.Properties,
 		}, typeMapper)
+	}
+
+	// Append `| null` for nullable fields so the type reflects what the API actually
+	// sends (Go marshals nil pointers/slices as JSON null, not as an absent key).
+	if result.Nullable {
+		result.Type += " | null"
 	}
 
 	// apply hook

--- a/typescript/typescript_client.go
+++ b/typescript/typescript_client.go
@@ -343,8 +343,6 @@ func convertTSType(models *tsModels, interfacesCache map[string]interface{}, in 
 		}, typeMapper)
 	}
 
-	// Append `| null` for nullable fields so the type reflects what the API actually
-	// sends (Go marshals nil pointers/slices as JSON null, not as an absent key).
 	if result.Nullable {
 		result.Type += " | null"
 	}

--- a/typescript/typescript_template.go
+++ b/typescript/typescript_template.go
@@ -6,7 +6,7 @@ const client = `/* Code generated from jsonrpc schema by rpcgen v{{ .Version }} 
 export interface {{ .Name }} {
 {{- $len := len .Parameters }}
 {{- range $i, $e := .Parameters }}
-  {{ .Name }}{{ if .Optional }}?{{ end }}: {{ .Type }}{{ if ne $i $len }},{{ end }}{{ if ne .Comment "" }} // {{ .Comment }}
+  {{ .Name }}: {{ .Type }}{{ if ne $i $len }},{{ end }}{{ if ne .Comment "" }} // {{ .Comment }}
 {{- end }}
 {{- end }}
 }
@@ -18,7 +18,7 @@ export class {{ .ModelName }} implements {{ .Name }} {
   static entityName = "{{ .EntityNameTmpl }}";
 {{ $len := len .Parameters }}
 {{- range $i,$e := .Parameters }}
-  {{ .Name }}{{ if .Optional }}?{{ end }}: {{ .Type }} = {{ .DefaultTmpl }};
+  {{ .Name }}: {{ .Type }} = {{ .DefaultTmpl }};
 {{- end }}
 }
 {{ end }}

--- a/typescript/typescript_template.go
+++ b/typescript/typescript_template.go
@@ -6,7 +6,7 @@ const client = `/* Code generated from jsonrpc schema by rpcgen v{{ .Version }} 
 export interface {{ .Name }} {
 {{- $len := len .Parameters }}
 {{- range $i, $e := .Parameters }}
-  {{ .Name }}: {{ .Type }}{{ if ne $i $len }},{{ end }}{{ if ne .Comment "" }} // {{ .Comment }}
+  {{ .Name }}{{ if .Nullable }}?{{ end }}: {{ .Type }}{{ if ne $i $len }},{{ end }}{{ if ne .Comment "" }} // {{ .Comment }}
 {{- end }}
 {{- end }}
 }
@@ -18,7 +18,7 @@ export class {{ .ModelName }} implements {{ .Name }} {
   static entityName = "{{ .EntityNameTmpl }}";
 {{ $len := len .Parameters }}
 {{- range $i,$e := .Parameters }}
-  {{ .Name }}: {{ .Type }} = {{ .DefaultTmpl }};
+  {{ .Name }}{{ if .Nullable }}?{{ end }}: {{ .Type }} = {{ .DefaultTmpl }};
 {{- end }}
 }
 {{ end }}

--- a/typescript/typescript_template.go
+++ b/typescript/typescript_template.go
@@ -6,7 +6,7 @@ const client = `/* Code generated from jsonrpc schema by rpcgen v{{ .Version }} 
 export interface {{ .Name }} {
 {{- $len := len .Parameters }}
 {{- range $i, $e := .Parameters }}
-  {{ .Name }}{{ if .Nullable }}?{{ end }}: {{ .Type }}{{ if ne $i $len }},{{ end }}{{ if ne .Comment "" }} // {{ .Comment }}
+  {{ .Name }}{{ if .Optional }}?{{ end }}: {{ .Type }}{{ if ne $i $len }},{{ end }}{{ if ne .Comment "" }} // {{ .Comment }}
 {{- end }}
 {{- end }}
 }
@@ -18,7 +18,7 @@ export class {{ .ModelName }} implements {{ .Name }} {
   static entityName = "{{ .EntityNameTmpl }}";
 {{ $len := len .Parameters }}
 {{- range $i,$e := .Parameters }}
-  {{ .Name }}{{ if .Nullable }}?{{ end }}: {{ .Type }} = {{ .DefaultTmpl }};
+  {{ .Name }}{{ if .Optional }}?{{ end }}: {{ .Type }} = {{ .DefaultTmpl }};
 {{- end }}
 }
 {{ end }}


### PR DESCRIPTION
The generated TypeScript client currently declares nullable fields (Go pointers/optional values) as `field?: T`, which in TS means `T or omitted from object`, as if the field were "cut out" from the JSON response. This does not correspond to the behavior of the real API: the zenrpc/Go server serializes nil as "field": null (the field is present with a null value), rather than omitting them.

- `| null` reflects the real shape of the **response** 
- `?` is kept for the **request** side — the server accepts requests with the field omitted